### PR TITLE
Removed man options that were conflicting with MacOSX

### DIFF
--- a/pcmpl-args.el
+++ b/pcmpl-args.el
@@ -785,7 +785,7 @@ insert its content into the current buffer.")
     ;; line, reducing the number of false positives that result from lines
     ;; starting with `-' that aren't really options.
     (push "MANWIDTH=10000" process-environment)
-    (pcmpl-args-process-file "man" "--nj" "--nh" "--" name)))
+    (pcmpl-args-process-file "man" name)))
 
 (defun pcmpl-args-extract-argspecs-from-manpage (name &rest args)
   "Return a list of argspecs by parsing the manpage identified by NAME.
@@ -3640,10 +3640,6 @@ will print completions for `ls -'."
 ;;   (should (member "ls" (pcmpl-args--debug-all-completions "xargs -d '\\n' ls")))
 ;;   (should (member "--format" (pcmpl-args--debug-all-completions "xargs -d '\\n' ls -")))
 ;;   (should (member "across" (pcmpl-args--debug-all-completions "xargs -d '\\n' ls --format "))))
-;;
-;; (ert-deftest pcmpl-args-test-man  ()
-;;   (should (member "--nj" (pcmpl-args--debug-all-completions "man -")))
-;;   (should (member "ascii" (pcmpl-args--debug-all-completions "man 7 a"))))
 ;;
 ;; (ert-deftest pcmpl-args-test-bzr  ()
 ;;   (should (member "help" (pcmpl-args--debug-all-completions "bzr ")))


### PR DESCRIPTION
Hello,

On MacOSX man there is no --nj option available for man. It was breaking pcmpl-args. I can't find what --nj means, even on linux "man man" page: http://linux.about.com/od/commands/l/blcmdl1_man.htm . When I did this change it is working on my machine.

Thanks,
Robert
