### PR TITLE
Fixed too many subcommmands for git completions

### DIFF
--- a/pcmpl-args.el
+++ b/pcmpl-args.el
@@ -3129,10 +3129,15 @@ options found in its man page."
       (pcmpl-args-process-file "git" "help" "-a")
       (goto-char (point-min))
       (let ((cmds (copy-sequence pcmpl-args-git-commands)))
-        (while (re-search-forward "^[ ]+[[:alpha:]].*$" nil t)
-          (dolist (cmd (split-string (match-string 0)))
+        (while (re-search-forward
+                "^[\t\s]+\\([^[:space:]]+\\)[\t\s]*\\([^[:space:]]*\\)$"
+                nil t)
+          (let ((cmd (match-string 1))
+                (help (match-string 2)))
+            (when (member help '(nil ""))
+              (setq help "..."))
             (unless (assoc cmd cmds)
-              (push (list cmd "...") cmds))))
+              (push (list cmd help) cmds))))
         (setq cmds
               (sort cmds (lambda (a b) (string-lessp (car a) (car b)))))
         (pcmpl-args-completion-table-with-annotations


### PR DESCRIPTION
2021-07-19  Valeriy Litkovskyy  <vlr.ltkvsk@protonmail.com>

	* pcmpl-args.el (pcmpl-args-git-commands): it does not give too
	many subcommands anymore.  Help annotations for subcommands are
	now correctly set.

Fixes #9 