### PR TITLE
Fix $PREFIX completion

### DIFF
--- a/pcmpl-args.el
+++ b/pcmpl-args.el
@@ -1664,6 +1664,7 @@ ARGSPECS should be value a created with
 `pcmpl-args-make-argspecs'."
   (noreturn
    (progn
+     (run-hooks 'pcomplete-try-first-hook)
      (pcmpl-args-debug "\n\n================================")
      (cl-assert (= pcomplete-last (1- (length pcomplete-args))) t)
      (let* ((result (pcmpl-args-parse-arguments (cdr pcomplete-args) argspecs))


### PR DESCRIPTION
Fixes #22 for all functions defined in this package except `pcomplete/dd`. For `dd` however, it makes sense to have this disabled as `dd` uses a unique argument syntax which breaks Elisp completion anyways.